### PR TITLE
Fix bug with host parsing

### DIFF
--- a/lib/watchman.ex
+++ b/lib/watchman.ex
@@ -3,7 +3,7 @@ defmodule Watchman do
 
   def start_link(options \\ []) do
     state = %{
-      host: options[:host] || Application.get_env(:watchman, :host) |> parse_host,
+      host: (options[:host] || Application.get_env(:watchman, :host)) |> parse_host,
       port: options[:port] || Application.get_env(:watchman, :port),
       prefix: options[:prefix] || Application.get_env(:watchman, :prefix)
     }

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -8,7 +8,7 @@ defmodule WatchmanTest do
     TestUDPServer.start_link(port: @test_port)
 
     {:ok, watchman} = Watchman.start_link([
-      host: 'localhost',
+      host: "localhost",
       port: @test_port,
       prefix: "test.prod"
     ])


### PR DESCRIPTION
Host from `options` will be parsed if it is `string (binary)`
