### PR TITLE
Duration instead of 1

### DIFF
--- a/lib/watchman/heartbeat.ex
+++ b/lib/watchman/heartbeat.ex
@@ -6,16 +6,20 @@ defmodule Watchman.Heartbeat do
   end
 
   def init(args) do
-    send(self(), {:submit_heartbeat, args[:interval] * 1000})
+    send(self(), {:submit_heartbeat, args[:interval] * 1000, now})
 
     {:ok, :ok}
   end
 
-  def handle_info(message = {:submit_heartbeat, interval}, :ok) do
-    Watchman.submit("heartbeat", 1, :gauge)
+  def handle_info(message = {:submit_heartbeat, interval, start_time}, :ok) do
+    Watchman.submit("heartbeat", now - start_time, :gauge)
 
-    :timer.send_after(interval, message)
+    :timer.send_after(interval, message, start_time)
 
     {:noreply, :ok}
+  end
+
+  defp now do
+    :calendar.datetime_to_gregorian_seconds(:calendar.universal_time)
   end
 end

--- a/lib/watchman/heartbeat.ex
+++ b/lib/watchman/heartbeat.ex
@@ -14,7 +14,7 @@ defmodule Watchman.Heartbeat do
   def handle_info(message = {:submit_heartbeat, interval, start_time}, :ok) do
     Watchman.submit("heartbeat", now - start_time, :gauge)
 
-    :timer.send_after(interval, message, start_time)
+    :timer.send_after(interval, message)
 
     {:noreply, :ok}
   end

--- a/test/lib/watchman/heartbeat_test.exs
+++ b/test/lib/watchman/heartbeat_test.exs
@@ -11,8 +11,12 @@ defmodule WatchmanHeartbeatTest do
 
   test "heartbeat test" do
     {:ok, hb} = Watchman.Heartbeat.start_link([interval: 1])
-    :timer.sleep(2000)
+    :timer.sleep(5000)
 
-    assert TestUDPServer.last_message == "watchman.test.heartbeat:1|g"
+    assert TestUDPServer.last_message == "watchman.test.heartbeat:4|g"
+
+    :timer.sleep(3000)
+
+    assert TestUDPServer.last_message == "watchman.test.heartbeat:7|g"
   end
 end


### PR DESCRIPTION
Send the duration of the life of the application as the value for heartbeat instead of '1'.
