### PR TITLE
Memory metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,26 @@ And it is right thing to do.
 
 There can be 3 tag values at the most.
 (If you need more - shout.)
+
+## System metrics
+
+You can gather system metrics simply by adding a `Watchman.System` worker to
+your supervisor.
+
+The following will send a bundle of metrics to your metrics server every `60`
+seconds:
+
+``` elixir
+worker(Watchman.System, [[interval: 60]])
+```
+
+The following metrics are sent:
+
+- system.memory.total
+- system.memory.processes
+- system.memory.processes_used
+- system.memory.atom
+- system.memory.atom_used
+- system.memory.binary
+- system.memory.code
+- system.memory.ets

--- a/lib/watchman/system.ex
+++ b/lib/watchman/system.ex
@@ -1,0 +1,34 @@
+defmodule Watchman.System do
+  use GenServer
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def init(args) do
+    interval = args[:interval] || 60 # seconds
+
+    send(self(), {:submit, interval * 1000})
+
+    {:ok, :ok}
+  end
+
+  def handle_info(message = {:submit, interval}, :ok) do
+    submit_memory
+
+    :timer.send_after(interval, message)
+
+    {:noreply, :ok}
+  end
+
+  def submit_memory do
+    Watchman.submit("system.memory.total", :erlang.memory |> Keyword.get(:total))
+    Watchman.submit("system.memory.processes", :erlang.memory |> Keyword.get(:processes))
+    Watchman.submit("system.memory.processes_used", :erlang.memory |> Keyword.get(:processes_used))
+    Watchman.submit("system.memory.atom", :erlang.memory |> Keyword.get(:atom))
+    Watchman.submit("system.memory.atom_used", :erlang.memory |> Keyword.get(:atom_used))
+    Watchman.submit("system.memory.binary", :erlang.memory |> Keyword.get(:binary))
+    Watchman.submit("system.memory.code", :erlang.memory |> Keyword.get(:code))
+    Watchman.submit("system.memory.ets", :erlang.memory |> Keyword.get(:ets))
+  end
+end


### PR DESCRIPTION
When I create a fresh new microservice I want to be able to do the following:

- add heartbeats to my service
- add basic system metrics

I want to achieve this as simply as possible. No configuration, no hassle. Also, I don't want to add N gems to achieve this.

This is an opt-in value for ex-watchman:

``` elixir
worker(Watchman.System, [[interval: 60]])
```

If you need simple metrics you can get them simply by adding the above.