### PR TITLE
Watchman should not break with "0.0.0.0" host

### DIFF
--- a/lib/watchman/server.ex
+++ b/lib/watchman/server.ex
@@ -21,9 +21,9 @@ defmodule Watchman.Server do
       raise "Watchman Prefix is not defined"
     end
 
-    state = %{ state | host: parse_host(state.host) }
-
     Logger.info "Watchman sending metrics to #{state.host}:#{state.port} with prefix '#{state.prefix}'"
+
+    state = %{ state | host: parse_host(state.host) }
 
     GenServer.start_link(__MODULE__, state, [name: __MODULE__])
   end


### PR DESCRIPTION
When we pass `host: "0.0.0.0"` it is converted to `{0,0,0,0}` so it could be 
passed to `:gen_udp.send`.

The issue was that `{0,0,0,0}` is not converted into string in the log line and an exception was raised.

To resolve this, I could have done one of:

1) Use `inspect(state.host)`. This would log `{0,0,0,0}:8129` on the log line
2) Move the logging before a line up, before the host is converted to the gen_udp format. This will print `0.0.0.0:8125`.

I choose option (2) because it is easier to understand while reading the logs of an application.