### PR TITLE
Backpressure for submitting metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ config :watchman,
 ## Usage
 
 Never name metric with variable:
+
 ```elixir
 Watchman.submit("user.#{id}.count", 30)
 ```
+
 If you need something like that, you probably need [tags](#tags)!
 
 ### Heartbeat
+
 To keep track if the application is running, use the heartbeat feature. Define
 a child process in the supervisor with a defined interval between notifications
 (in seconds), like so:
@@ -253,4 +256,26 @@ When set up, this will generate the following metrics:
 
 5. total time spend for the transaction in DB native units (nanosecs)
 <watchman-prefix>.transaction.duration, with tags: [repo_name, table_name, "total"]
+```
+
+## Advanced configuration
+
+### Buffer Size
+
+Watchman has a limited buffer size for unprocessed messages (metrics that are
+waiting to be submitted via UDP).
+
+This limit is set in order to avoid accidental accumulation of messages in
+Watchman.Server's message box.
+
+The default value is unprocessed 10_000 messages.
+
+To change the default value, set a new value in the config:
+
+``` elixir
+config :watchman,
+  host: "statistics.example.com",
+  port: 22001,
+  prefix: "my-service.prod"
+  max_buffer_size: 50            # <----- sets the buffer to 50 messages
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,5 +2,5 @@ use Mix.Config
 
 config :watchman,
   host: "localhost",
-  port: 8129,
+  port: 8125,
   prefix: "watchman.test"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,5 +2,5 @@ use Mix.Config
 
 config :watchman,
   host: "localhost",
-  port: 8125,
+  port: 8129,
   prefix: "watchman.test"

--- a/lib/watchman.ex
+++ b/lib/watchman.ex
@@ -13,7 +13,7 @@ defmodule Watchman do
   end
 
   def submit(name, value, type \\ :gauge) do
-    GenServer.cast(Watchman.Server, {:send, name, value, type})
+    Watchman.Server.submit(name, value, type)
   end
 
   def increment(name) do

--- a/lib/watchman/server.ex
+++ b/lib/watchman/server.ex
@@ -54,7 +54,15 @@ defmodule Watchman.Server do
   def handle_cast_(name, tag_list, value, type, state) do
     package = statsd_package(state.prefix, name, tag_list |> tags, value, type)
 
-    :gen_udp.send(state.socket, state.host, state.port, package)
+    t = :timer.tc(fn ->
+      # {:ok, socket} = :gen_udp.open(0, [:binary])
+
+      :gen_udp.send(state.socket, state.host, state.port, package)
+
+      # :gen_udp.close(socket)
+    end)
+
+    IO.inspect("gen_udp.send took: #{elem(t, 0) / 1000} ms")
 
     {:noreply, state}
   end

--- a/test/lib/watchman/benchmark_test.exs
+++ b/test/lib/watchman/benchmark_test.exs
@@ -1,14 +1,6 @@
 defmodule Watchman.BenchmarkTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   use Watchman.Benchmark
-
-  @test_port 8125
-
-  setup do
-    TestUDPServer.start_link(port: @test_port)
-
-    :ok
-  end
 
   @benchmark(key: :auto)
   def simple1 do
@@ -37,34 +29,46 @@ defmodule Watchman.BenchmarkTest do
   end
 
   test "benchmark annotation auto key test" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     simple1
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message =~ ~r/watchman.test.watchman.benchmark_test.simple:10\d\d|ms/
   end
 
   test "benchmark annotation manual key test" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     simple2
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message =~ ~r/watchman.test.watchman.benchmark_test.charlie:10\d\d|ms/
   end
 
   test "function returns the proper return value" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     result = add(1, 2)
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message =~ ~r/watchman.test.watchman.benchmark_test.add:\d*|ms/
     assert result == 3
   end
 
   test "function guards" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     result = sum(3, 5)
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message =~ ~r/watchman.test.watchman.benchmark_test.sum:\d*|ms/
     assert result == 8

--- a/test/lib/watchman/heartbeat_test.exs
+++ b/test/lib/watchman/heartbeat_test.exs
@@ -1,15 +1,10 @@
 defmodule WatchmanHeartbeatTest do
-  use ExUnit.Case
-
-  @test_port 8125
-
-  setup do
-    TestUDPServer.start_link(port: @test_port)
-
-    :ok
-  end
+  use ExUnit.Case, async: false
 
   test "heartbeat test" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     {:ok, hb} = Watchman.Heartbeat.start_link([interval: 1])
     :timer.sleep(5000)
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,27 +1,60 @@
 defmodule TestUDPServer do
   use GenServer
 
-  def start_link(options) do
-    GenServer.start_link(__MODULE__, options, [name: __MODULE__])
+  @test_port 8125
+
+  def start_link() do
+    pid = Process.whereis(__MODULE__)
+
+    if pid do
+      {:ok, pid}
+    else
+      GenServer.start_link(__MODULE__, [], [name: __MODULE__])
+    end
   end
 
-  def init([port: port]) do
-    {:ok, _} = :gen_udp.open(port, [:binary, active: true])
+  def wait_for_clean_message_box do
+    pid = Process.whereis(__MODULE__)
+    {:message_queue_len, len} = Process.info(pid, :message_queue_len)
+
+    if len > 0 do
+      :timer.sleep(100)
+      wait_for_clean_message_box()
+    end
+
+    :ok
+  end
+
+  def flush do
+    GenServer.call(__MODULE__, :flush)
+  end
+
+  def init([]) do
+    {:ok, _} = :gen_udp.open(@test_port, [:binary, active: true])
 
     {:ok, []}
   end
 
   def last_message do
+    wait_for_clean_message_box()
+
     GenServer.call(__MODULE__, :last_message)
   end
 
   def handle_info({_udp, _socket, _host, _port, package}, messages) do
-    {:noreply, [package| messages]}
+    {:noreply, [package | messages]}
+  end
+
+  def handle_call(:flush, _from, messages) do
+    {:reply, nil, [:nothing]}
   end
 
   def handle_call(:last_message, _from, messages) do
+    IO.inspect messages
     {:reply, hd(messages), messages}
   end
 end
+
+TestUDPServer.start_link()
 
 ExUnit.start(trace: true)

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -1,14 +1,6 @@
 defmodule WatchmanTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   use Watchman.Count
-
-  @test_port 8125
-
-  setup do
-    TestUDPServer.start_link(port: @test_port)
-
-    :ok
-  end
 
   @count(key: :auto)
   def test_function3 do
@@ -21,99 +13,152 @@ defmodule WatchmanTest do
   end
 
   test "submit with no type" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.submit("user.count", 30)
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
             "tagged.watchman.test.no_tag.no_tag.no_tag.user.count:30|g"
   end
 
   test "submit with timing type" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.submit("setup.duration", 30, :timing)
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
             "tagged.watchman.test.no_tag.no_tag.no_tag.setup.duration:30|ms"
   end
 
   test "submit with counter type - 1 tag" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.submit({"setup.duration", [:tag]}, 30, :count)
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
             "tagged.watchman.test.tag.no_tag.no_tag.setup.duration:30|c"
   end
 
   test "submit with counter type - 3 tags" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.submit({"setup.duration", [:tag1, :tag2, :tag3]}, 30, :count)
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
             "tagged.watchman.test.tag1.tag2.tag3.setup.duration:30|c"
   end
 
   test "submit with counter type - 4 tags - dissregarded" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.submit({"setup.duration", [:tag1, :tag2, :tag3]}, 30, :count)
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
             "tagged.watchman.test.tag1.tag2.tag3.setup.duration:30|c"
   end
 
   test "increment with counter type" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.increment("increment")
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
             "tagged.watchman.test.no_tag.no_tag.no_tag.increment:1|c"
   end
 
   test "decrement with counter type" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.decrement("decrement")
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
             "tagged.watchman.test.no_tag.no_tag.no_tag.decrement:-1|c"
   end
 
   test "benchmark code execution" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     Watchman.benchmark("sleep.duration", fn ->
       :timer.sleep(500)
     end)
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message =~ ~r/watchman.test.sleep.duration:5\d\d|ms/
   end
 
   test "count annotation auto key test" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     test_function3
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
       "tagged.watchman.test.no_tag.no_tag.no_tag.watchman_test.test_function3:1|c"
   end
 
   test "count annotation manual key test" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
     test_function4
 
-    :timer.sleep(500)
+    :timer.sleep(1000)
 
     assert TestUDPServer.last_message ==
       "tagged.watchman.test.no_tag.no_tag.no_tag.because.of.the.implication:1|c"
   end
 
-  test "sending metrics to a broken statsd" do
-    Enum.each(1..1000, fn _ ->
-      Watchman.increment("increment")
+  test "submitting metrics to watchman is fast" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
+    {time, :ok} = :timer.tc(fn ->
+      Enum.each(1..1000, fn _ -> Watchman.increment("increment") end)
     end)
 
-    :timer.sleep(1000)
+    IO.puts "\nSubmiting to watchman took: #{time}ms"
 
+    #
+    # submitting 1000 metrics should take less then a 5 miliseconds
+    #
+    # We only want a referent duration here that is acceptable.
+    #
+    assert time/1000 < 5
+  end
+
+  test "watchman server has an upper limit of metrics" do
+    TestUDPServer.wait_for_clean_message_box()
+    TestUDPServer.flush()
+
+    max_buffer_size = Watchman.Server.max_buffer_size()
     pid = Process.whereis(Watchman.Server)
-    assert Process.info(pid, :message_queue_len) == {:message_queue_len, 0}
+
+    Enum.each(1..(max_buffer_size*5), fn _ -> Watchman.increment("increment") end)
+
+    {:message_queue_len, len} = Process.info(pid, :message_queue_len)
+
+    IO.puts "\nMessage queue len: #{len}"
+
+    assert len <= max_buffer_size
   end
 
 end

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -105,4 +105,15 @@ defmodule WatchmanTest do
       "tagged.watchman.test.no_tag.no_tag.no_tag.because.of.the.implication:1|c"
   end
 
+  test "sending metrics to a broken statsd" do
+    Enum.each(1..1000, fn _ ->
+      Watchman.increment("increment")
+    end)
+
+    :timer.sleep(1000)
+
+    pid = Process.whereis(Watchman.Server)
+    assert Process.info(pid, :message_queue_len) == {:message_queue_len, 0}
+  end
+
 end


### PR DESCRIPTION
In this PR we are introducing a buffer size for unprocessed messages. This is a safety measure to avoid memory overflows caused by excessive incoming metrics. I'm following the "It is safer to drop metrics than to kill a service" phylosophy.

The default is set to be 10000 unprocessed messages.

The idea is based on Elixir logger's implementation https://github.com/elixir-lang/elixir/blob/v1.7/lib/logger/lib/logger/config.ex#L110-L121.