### PR TITLE
add regex whitelist to filter messages

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,6 +24,6 @@ blocks:
       jobs:
         - name: Elixir code check
           commands:
-            - mix loca.hex --force
+            - mix local.hex --force
             - mix deps.get --only test
             - mix test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,29 @@
+version: v1.0
+name: Build & Test
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+auto_cancel:
+  running:
+    when: 'true'
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+blocks:
+  - name: Tests
+    dependencies: []
+    task:
+      epilogue:
+        always:
+          commands:
+            - if [ -f assets/results.xml ]; then mv assets/results.xml results.xml; fi
+            - if [ -f results.xml ]; then test-results publish results.xml; fi
+
+      jobs:
+        - name: Elixir code check
+          commands:
+            - mix loca.hex --force
+            - mix deps.get --only test
+            - mix test

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,4 +3,5 @@ use Mix.Config
 config :watchman,
   host: "localhost",
   port: 8125,
-  prefix: "watchman.test"
+  prefix: "watchman.test",
+  whitelist: ".*"

--- a/lib/watchman.ex
+++ b/lib/watchman.ex
@@ -13,20 +13,27 @@ defmodule Watchman do
   end
 
   def submit(name, value, type \\ :gauge) do
-    Watchman.Server.submit(name, value, type)
+    Watchman.Server.submit(name, value, false, type)
   end
 
-  def increment(name) do
-    submit(name, 1, :count)
+  def submit(name, value, external, type) do
+    Watchman.Server.submit(name, value, external, type)
   end
 
-  def decrement(name) do
-    submit(name, -1, :count)
+  def increment(name), do: increment(name, false)
+  def increment(name, external) do
+    submit(name, 1, external, :count)
   end
 
-  def benchmark(name, function) do
+  def decrement(name), do: decrement(name, false)
+  def decrement(name, external) do
+    submit(name, -1, external, :count)
+  end
+
+  def benchmark(name, function), do: benchmark(name, false, function)
+  def benchmark(name, external, function) do
     {duration, result} = function |> :timer.tc
-    submit(name, div(duration, 1000), :timing)
+    submit(name, div(duration, 1000), external, :timing)
     result
   end
 end

--- a/lib/watchman.ex
+++ b/lib/watchman.ex
@@ -9,6 +9,9 @@ defmodule Watchman do
     ]
 
     opts = [strategy: :one_for_one, name: __MODULE__]
+    opts = if Mix.env() == :test do
+      Keyword.put_new(opts, :max_restarts, 10)
+    end
     Supervisor.start_link(children, opts)
   end
 

--- a/lib/watchman/benchmark.ex
+++ b/lib/watchman/benchmark.ex
@@ -60,7 +60,7 @@ defmodule Watchman.Benchmark do
     # so that the time taken to execute the function body can be measured
     quote do
       Watchman.benchmark(unquote(benchmark_data.key), fn ->
-        unquote(benchmark_data.body)
+        unquote(Keyword.get(benchmark_data.body, :do))
       end)
     end
   end

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -2,12 +2,12 @@ defmodule WatchmanTest do
   use ExUnit.Case, async: false
   use Watchman.Count
 
-  @count(key: :auto)
+  @count key: :auto
   def test_function3 do
     :timer.sleep(200)
   end
 
-  @count(key: "because.of.the.implication")
+  @count key: "because.of.the.implication"
   def test_function4 do
     :timer.sleep(200)
   end
@@ -20,8 +20,8 @@ defmodule WatchmanTest do
 
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-            "tagged.watchman.test.no_tag.no_tag.no_tag.user.count:30|g"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.no_tag.no_tag.no_tag.user.count:30|g"
   end
 
   test "submit with timing type" do
@@ -31,8 +31,8 @@ defmodule WatchmanTest do
     Watchman.submit("setup.duration", 30, :timing)
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-            "tagged.watchman.test.no_tag.no_tag.no_tag.setup.duration:30|ms"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.no_tag.no_tag.no_tag.setup.duration:30|ms"
   end
 
   test "submit with counter type - 1 tag" do
@@ -42,8 +42,8 @@ defmodule WatchmanTest do
     Watchman.submit({"setup.duration", [:tag]}, 30, :count)
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-            "tagged.watchman.test.tag.no_tag.no_tag.setup.duration:30|c"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.tag.no_tag.no_tag.setup.duration:30|c"
   end
 
   test "submit with counter type - 3 tags" do
@@ -53,8 +53,8 @@ defmodule WatchmanTest do
     Watchman.submit({"setup.duration", [:tag1, :tag2, :tag3]}, 30, :count)
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-            "tagged.watchman.test.tag1.tag2.tag3.setup.duration:30|c"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.tag1.tag2.tag3.setup.duration:30|c"
   end
 
   test "submit with counter type - 4 tags - dissregarded" do
@@ -64,8 +64,8 @@ defmodule WatchmanTest do
     Watchman.submit({"setup.duration", [:tag1, :tag2, :tag3]}, 30, :count)
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-            "tagged.watchman.test.tag1.tag2.tag3.setup.duration:30|c"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.tag1.tag2.tag3.setup.duration:30|c"
   end
 
   test "increment with counter type" do
@@ -75,8 +75,8 @@ defmodule WatchmanTest do
     Watchman.increment("increment")
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-            "tagged.watchman.test.no_tag.no_tag.no_tag.increment:1|c"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.no_tag.no_tag.no_tag.increment:1|c"
   end
 
   test "decrement with counter type" do
@@ -86,8 +86,8 @@ defmodule WatchmanTest do
     Watchman.decrement("decrement")
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-            "tagged.watchman.test.no_tag.no_tag.no_tag.decrement:-1|c"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.no_tag.no_tag.no_tag.decrement:-1|c"
   end
 
   test "benchmark code execution" do
@@ -100,7 +100,7 @@ defmodule WatchmanTest do
 
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message =~ ~r/watchman.test.sleep.duration:5\d\d|ms/
+    assert TestUDPServer.last_message() =~ ~r/watchman.test.sleep.duration:5\d\d|ms/
   end
 
   test "count annotation auto key test" do
@@ -111,8 +111,8 @@ defmodule WatchmanTest do
 
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-      "tagged.watchman.test.no_tag.no_tag.no_tag.watchman_test.test_function3:1|c"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.no_tag.no_tag.no_tag.watchman_test.test_function3:1|c"
   end
 
   test "count annotation manual key test" do
@@ -123,26 +123,27 @@ defmodule WatchmanTest do
 
     :timer.sleep(1000)
 
-    assert TestUDPServer.last_message ==
-      "tagged.watchman.test.no_tag.no_tag.no_tag.because.of.the.implication:1|c"
+    assert TestUDPServer.last_message() ==
+             "tagged.watchman.test.no_tag.no_tag.no_tag.because.of.the.implication:1|c"
   end
 
   test "submitting metrics to watchman is fast" do
     TestUDPServer.wait_for_clean_message_box()
     TestUDPServer.flush()
 
-    {time, :ok} = :timer.tc(fn ->
-      Enum.each(1..1000, fn _ -> Watchman.increment("increment") end)
-    end)
+    {time, :ok} =
+      :timer.tc(fn ->
+        Enum.each(1..1000, fn _ -> Watchman.increment("increment") end)
+      end)
 
-    IO.puts "\nSubmiting to watchman took: #{time}ms"
+    IO.puts("\nSubmiting to watchman took: #{time}ms")
 
     #
     # submitting 1000 metrics should take less then a 5 miliseconds
     #
     # We only want a referent duration here that is acceptable.
     #
-    assert time/1000 < 5
+    assert time / 1000 < 5
   end
 
   test "watchman server has an upper limit of metrics" do
@@ -152,48 +153,51 @@ defmodule WatchmanTest do
     max_buffer_size = Watchman.Server.max_buffer_size()
     pid = Process.whereis(Watchman.Server)
 
-    Enum.each(1..(max_buffer_size*5), fn _ -> Watchman.increment("increment") end)
+    Enum.each(1..(max_buffer_size * 5), fn _ -> Watchman.increment("increment") end)
 
     {:message_queue_len, len} = Process.info(pid, :message_queue_len)
 
-    IO.puts "\nMessage queue len: #{len}"
+    IO.puts("\nMessage queue len: #{len}")
 
     assert len <= max_buffer_size
     # allow Watchman.Server time to clear it's buffer
     :timer.sleep(1000)
   end
 
-  describe ".external_only" do
+  describe ".external_only true" do
     setup do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
-
 
       Application.put_env(:watchman, :external_only, true)
       pid = Process.whereis(Watchman.Server)
       Process.exit(pid, :kill)
 
       :timer.sleep(1000)
+
       on_exit(fn ->
         Application.put_env(:watchman, :external_only, false)
         pid = Process.whereis(Watchman.Server)
         Process.exit(pid, :kill)
-       end)
+      end)
+
       :ok
     end
 
-    test "external_only: true, flag not sent => do not forward" do
+    test "flag not sent => do not forward" do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
-      Watchman.Server.buffer_size
+      Watchman.Server.buffer_size()
       Watchman.submit("internal.user.count", 30)
 
       :timer.sleep(1000)
 
-      assert TestUDPServer.last_message == :nothing
-              # "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
+      assert TestUDPServer.last_message() == :nothing
+      # "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
+    end
 
+    test "flag true => forward" do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
@@ -201,8 +205,77 @@ defmodule WatchmanTest do
 
       :timer.sleep(1000)
 
-      assert TestUDPServer.last_message ==
-              "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
+      assert TestUDPServer.last_message() ==
+               "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
+    end
+
+    test "flag false => do not forward" do
+      TestUDPServer.wait_for_clean_message_box()
+      TestUDPServer.flush()
+
+      Watchman.submit("internal.user.count", 30, false, :gauge)
+
+      :timer.sleep(1000)
+
+      assert TestUDPServer.last_message() == :nothing
+    end
+  end
+
+  describe ".external_only false" do
+    setup do
+      TestUDPServer.wait_for_clean_message_box()
+      TestUDPServer.flush()
+
+      Application.put_env(:watchman, :external_only, false)
+      pid = Process.whereis(Watchman.Server)
+      Process.exit(pid, :kill)
+
+      :timer.sleep(1000)
+
+      on_exit(fn ->
+        Application.put_env(:watchman, :external_only, false)
+        pid = Process.whereis(Watchman.Server)
+        Process.exit(pid, :kill)
+      end)
+
+      :ok
+    end
+
+    test "flag not sent => forward" do
+      TestUDPServer.wait_for_clean_message_box()
+      TestUDPServer.flush()
+
+      Watchman.Server.buffer_size()
+      Watchman.submit("internal.user.count", 30)
+
+      :timer.sleep(1000)
+
+      assert TestUDPServer.last_message() ==
+               "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
+    end
+
+    test "flag true => forward" do
+      TestUDPServer.wait_for_clean_message_box()
+      TestUDPServer.flush()
+
+      Watchman.submit("internal.user.count", 30, true, :gauge)
+
+      :timer.sleep(1000)
+
+      assert TestUDPServer.last_message() ==
+               "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
+    end
+
+    test "flag false => forward" do
+      TestUDPServer.wait_for_clean_message_box()
+      TestUDPServer.flush()
+
+      Watchman.submit("internal.user.count", 30, false, :gauge)
+
+      :timer.sleep(1000)
+
+      assert TestUDPServer.last_message() ==
+               "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
     end
   end
 end

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -163,7 +163,6 @@ defmodule WatchmanTest do
 
   describe ".whitelist" do
     setup do
-      # TestHelpers.start_with_opts(whitelist: "^external.*")
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -179,6 +179,7 @@ defmodule WatchmanTest do
         Application.put_env(:watchman, :external_only, false)
         pid = Process.whereis(Watchman.Server)
         Process.exit(pid, :kill)
+        :timer.sleep(500)
       end)
 
       :ok
@@ -188,13 +189,11 @@ defmodule WatchmanTest do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
-      Watchman.Server.buffer_size()
       Watchman.submit("internal.user.count", 30)
 
       :timer.sleep(1000)
 
       assert TestUDPServer.last_message() == :nothing
-      # "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
     end
 
     test "flag true => forward" do
@@ -236,6 +235,7 @@ defmodule WatchmanTest do
         Application.put_env(:watchman, :external_only, false)
         pid = Process.whereis(Watchman.Server)
         Process.exit(pid, :kill)
+        :timer.sleep(500)
       end)
 
       :ok
@@ -245,7 +245,6 @@ defmodule WatchmanTest do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
-      Watchman.Server.buffer_size()
       Watchman.submit("internal.user.count", 30)
 
       :timer.sleep(1000)

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -159,6 +159,8 @@ defmodule WatchmanTest do
     IO.puts "\nMessage queue len: #{len}"
 
     assert len <= max_buffer_size
+    # allow Watchman.Server time to clear it's buffer
+    :timer.sleep(1000)
   end
 
   describe ".external_only" do


### PR DESCRIPTION
The test seems to be flaky because `ExUnit supervisor` restarts the Watchman.Server with default whietlist in options.
