### PR TITLE
change filtering from bool flag to atom

### DIFF
--- a/lib/watchman.ex
+++ b/lib/watchman.ex
@@ -15,25 +15,25 @@ defmodule Watchman do
   end
 
   def submit(name, value, type \\ :gauge) do
-    Watchman.Server.submit(name, value, false, type)
+    Watchman.Server.submit(name, value, :internal, type)
   end
 
-  def submit(name, value, external, type) do
+  def submit(name, value, external, type) when external in [:internal, :external, :always]  do
     Watchman.Server.submit(name, value, external, type)
   end
 
-  def increment(name), do: increment(name, false)
+  def increment(name), do: increment(name, :internal)
   def increment(name, external) do
     submit(name, 1, external, :count)
   end
 
-  def decrement(name), do: decrement(name, false)
+  def decrement(name), do: decrement(name, :internal)
   def decrement(name, external) do
     submit(name, -1, external, :count)
   end
 
-  def benchmark(name, function), do: benchmark(name, false, function)
-  def benchmark(name, external, function) do
+  def benchmark(name, function), do: benchmark(name, :internal, function)
+  def benchmark(name, external, function) when external in [:internal, :external, :always] do
     {duration, result} = function |> :timer.tc
     submit(name, div(duration, 1000), external, :timing)
     result

--- a/test/watchman_test.exs
+++ b/test/watchman_test.exs
@@ -196,11 +196,23 @@ defmodule WatchmanTest do
       assert TestUDPServer.last_message() == :nothing
     end
 
-    test "flag true => forward" do
+    test "flag :always => forward" do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
-      Watchman.submit("internal.user.count", 30, true, :gauge)
+      Watchman.submit("internal.user.count", 31, :always, :gauge)
+
+      :timer.sleep(1000)
+
+      assert TestUDPServer.last_message() ==
+               "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:31|g"
+    end
+
+    test "flag :external => forward" do
+      TestUDPServer.wait_for_clean_message_box()
+      TestUDPServer.flush()
+
+      Watchman.submit("internal.user.count", 30, :external, :gauge)
 
       :timer.sleep(1000)
 
@@ -208,11 +220,11 @@ defmodule WatchmanTest do
                "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
     end
 
-    test "flag false => do not forward" do
+    test "flag :internal => do not forward" do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
-      Watchman.submit("internal.user.count", 30, false, :gauge)
+      Watchman.submit("internal.user.count", 30, :internal, :gauge)
 
       :timer.sleep(1000)
 
@@ -253,11 +265,11 @@ defmodule WatchmanTest do
                "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
     end
 
-    test "flag true => forward" do
+    test "flag :always => forward" do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
-      Watchman.submit("internal.user.count", 30, true, :gauge)
+      Watchman.submit("internal.user.count", 30, :always, :gauge)
 
       :timer.sleep(1000)
 
@@ -265,11 +277,22 @@ defmodule WatchmanTest do
                "tagged.watchman.test.no_tag.no_tag.no_tag.internal.user.count:30|g"
     end
 
-    test "flag false => forward" do
+    test "flag :external => do not forward" do
       TestUDPServer.wait_for_clean_message_box()
       TestUDPServer.flush()
 
-      Watchman.submit("internal.user.count", 30, false, :gauge)
+      Watchman.submit("internal.user.count", 30, :external, :gauge)
+
+      :timer.sleep(1000)
+
+      assert TestUDPServer.last_message() == :nothing
+    end
+
+    test "flag :internal => forward" do
+      TestUDPServer.wait_for_clean_message_box()
+      TestUDPServer.flush()
+
+      Watchman.submit("internal.user.count", 30, :internal, :gauge)
 
       :timer.sleep(1000)
 


### PR DESCRIPTION
So this will resolve one issue that I encountered, for external metrics we sometimes want to have different name to the internal one, and not to send metrics multiple times it would be useful to flag them for only external, only internal or both.
eg. this code:

```
    if Application.get_env(:watchman, :external_only) do
      Watchman.submit("some.internal.metric.name", count, :gauge)
    else
      Watchman.submit({"external.metric", ["name"]}, count, true, :gauge)
    end
```
becomes this:
```
      Watchman.submit("some.internal.metric.name", count, :gauge)
      Watchman.submit({"external.metric", ["name"]}, count, :external, :gauge)
```

Difference: bool flag becomes atom that can be one of `[:always, :internal, :external]`